### PR TITLE
docs(prd-8): mark Datadog observability complete

### DIFF
--- a/prds/8-datadog-observability.md
+++ b/prds/8-datadog-observability.md
@@ -142,12 +142,12 @@ Verification:
 
 ### 2026-01-27: OTLP Ingestion Approach (from PRD #6 research)
 
-**Finding:** Datadog's direct OTLP intake has different maturity levels:
-- Logs: GA
-- Metrics: GA
-- Traces: **LLM Observability only** (Preview for general APM)
+**Finding:** Datadog requires an intermediary for OTLP trace ingestion:
+- Direct OTLP to Datadog backend: **Not supported** (no public endpoint exists)
+- Via Datadog Agent: **GA** (v6.32.0+/v7.32.0+) - recommended approach
+- Via OpenTelemetry Collector with Datadog exporter: Supported alternative
 
-**Decision:** Use **Datadog Agent with OTLP ingestion** instead of direct OTLP to Datadog endpoint.
+**Decision:** Use **Datadog Agent with OTLP ingestion**.
 
 **Rationale:**
 - Datadog Agent v6.32.0+/v7.32.0+ supports OTLP ingestion on ports 4317 (gRPC) and 4318 (HTTP)
@@ -164,7 +164,7 @@ DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT=0.0.0.0:4318
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
 
-**Alternative:** If we specifically want Datadog's LLM Observability features, direct OTLP may work. Research in M1 should evaluate whether LLM Observability provides value for our demo.
+**Note:** Datadog's LLM Observability features work with traces ingested via the Agent - no special configuration needed beyond standard OTLP setup.
 
 ### 2026-02-02: Documentation Consolidation
 


### PR DESCRIPTION
## Summary

- Verified traces flow through local Datadog Agent (localhost:4318) to Datadog APM
- Confirmed span hierarchy displays correctly (MCP tool → kubectl subprocess)
- Documented consolidation of Datadog docs into `docs/opentelemetry.md`
- Deferred M4 (Demo Polish) - KubeCon is 6 weeks away, basic functionality complete

## Test plan

- [x] Ran `OTEL_TRACING_ENABLED=true OTEL_EXPORTER_TYPE=otlp OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` with complex query
- [x] Verified 119 spans appeared in Datadog APM for `service:cluster-whisperer`
- [x] Confirmed kubectl spans show proper parent-child hierarchy under tool spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated Datadog-related documentation into unified reference materials for streamlined access.

* **Chores**
  * Updated observability project status and advancement tracking.
  * Marked three core project milestones as completed with progress notes.
  * Deferred one milestone completion with appropriate status notation.
  * Verified completion of all success criteria checklist items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->