### PR TITLE
Close PRD #28 - superseded by Go/Kubebuilder controller

### DIFF
--- a/prds/done/28-cluster-sync-watcher.md
+++ b/prds/done/28-cluster-sync-watcher.md
@@ -1,7 +1,8 @@
 # PRD #28: Cluster Sync Watcher
 
-**Status**: Not Started
+**Status**: Superseded
 **Created**: 2026-02-18
+**Closed**: 2026-02-20
 **GitHub Issue**: [#28](https://github.com/wiggitywhitney/cluster-whisperer/issues/28)
 
 ---


### PR DESCRIPTION
## Summary
- Archive PRD #28 (Cluster Sync Watcher) to `prds/done/`
- TypeScript polling approach superseded by Go/Kubebuilder controller in new `k8s-vectordb-sync` repo
- No code changes, documentation only

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product documentation status to reflect superseded requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->