### PR TITLE
docs(prd-33): OTel peer dependencies for distribution

### DIFF
--- a/prds/33-otel-peer-dependencies.md
+++ b/prds/33-otel-peer-dependencies.md
@@ -102,11 +102,11 @@ The API package is ~50KB and designed to be present even when no SDK is configur
 },
 "peerDependencies": {
   "@opentelemetry/api": "^1.9.0",
-  "@opentelemetry/exporter-trace-otlp-proto": "^0.203.0",
-  "@opentelemetry/resources": "^2.0.0",
-  "@opentelemetry/sdk-node": "^0.203.0",
-  "@opentelemetry/sdk-trace-node": "^2.0.0",
-  "@opentelemetry/semantic-conventions": "^1.38.0",
+  "@opentelemetry/exporter-trace-otlp-proto": "^0.211.0",
+  "@opentelemetry/resources": "^2.5.0",
+  "@opentelemetry/sdk-node": "^0.211.0",
+  "@opentelemetry/sdk-trace-node": "^2.5.0",
+  "@opentelemetry/semantic-conventions": "^1.39.0",
   "@traceloop/node-server-sdk": "~0.22.6"
 },
 "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary
- Created PRD #33 for refactoring OTel packages from direct to peer dependencies
- `@opentelemetry/api` becomes a required peer dependency; SDK packages become optional peers
- Defined 6 milestones with Datadog MCP verification before/after refactor

## Test plan
- [ ] PRD content reviewed for completeness and accuracy
- [ ] No code changes — PRD only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Product Requirements Document #33 outlining a phased plan to adjust OpenTelemetry peer dependency handling, with milestones, acceptance criteria, migration approach, verification steps, and success metrics for enabling optional telemetry components and graceful degradation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->