### PR TITLE
fix(test): use top-level imports in vectorstore OTel span tests

### DIFF
--- a/src/vectorstore/chroma-backend.test.ts
+++ b/src/vectorstore/chroma-backend.test.ts
@@ -11,7 +11,7 @@ import {
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
 import type { EmbeddingFunction } from "./types";
 // Pre-import the module under test at the top level to avoid slow dynamic imports.
-// The vi.mock("chromadb") above is hoisted, so this import gets the mocked version.
+// vi.mock("chromadb") below is hoisted by Vitest, so this import gets the mocked version.
 import { ChromaBackend } from "./chroma-backend";
 
 // ---------------------------------------------------------------------------

--- a/src/vectorstore/embeddings.test.ts
+++ b/src/vectorstore/embeddings.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@opentelemetry/sdk-trace-node";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
 // Pre-import the module under test at the top level to avoid slow dynamic imports.
-// The vi.mock("voyageai") above is hoisted, so this import gets the mocked version.
+// vi.mock("voyageai") below is hoisted by Vitest, so this import gets the mocked version.
 import { VoyageEmbedding } from "./embeddings";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace dynamic `await import()` with top-level imports in `chroma-backend.test.ts` and `embeddings.test.ts`
- Dynamic imports triggered full dependency chain resolution (chromadb SDK, voyageai SDK) on every helper call, exceeding the 5s default timeout on slower machines
- Top-level imports resolve the module once at load time with the hoisted `vi.mock()` already in place
- Test execution time dropped from ~500ms to ~19ms

## Test plan
- [x] Both vectorstore OTel span test files pass (39 tests total)
- [x] Full test suite passes (377 passed, 68 skipped for missing cluster/API, 0 failed)
- [x] Build and typecheck pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated vector store tests to use top-level imports and a synchronous embedder factory so mocked dependencies are consistently applied. Removed dynamic import patterns in test setup to stabilize mock hoisting and simplify test control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->