### PR TITLE
fix(agent): raise LangGraph recursion limit from 25 to 50

### DIFF
--- a/src/agent/investigator.test.ts
+++ b/src/agent/investigator.test.ts
@@ -85,7 +85,7 @@ describe("getInvestigatorAgent", () => {
 describe("RECURSION_LIMIT", () => {
   it("exports a recursion limit constant", async () => {
     const { RECURSION_LIMIT } = await import("./investigator");
-    expect(RECURSION_LIMIT).toBe(25);
+    expect(RECURSION_LIMIT).toBe(50);
   });
 });
 

--- a/src/agent/investigator.ts
+++ b/src/agent/investigator.ts
@@ -46,11 +46,12 @@ export const ANTHROPIC_MODEL = "claude-sonnet-4-20250514";
  * not at agent creation. The default is 25, but we make it explicit and export
  * it so both the CLI (streamEvents) and MCP (invoke) use the same limit.
  *
- * Why 25? Normal investigations use 5-10 tool calls. 25 is high enough for
- * complex multi-step investigations but low enough to prevent runaway loops
- * (e.g., model retrying a failing kubectl command indefinitely).
+ * Why 50? Normal investigations use 5-10 tool calls. Complex demo flows
+ * (vector search → failed deploy → retry → describe → more searches) can
+ * exceed 25 steps. 50 is generous enough for multi-step Act 3 flows while
+ * still preventing runaway loops.
  */
-export const RECURSION_LIMIT = 25;
+export const RECURSION_LIMIT = 50;
 
 /**
  * Result from invoking the investigator agent.


### PR DESCRIPTION
## Summary
- Raises the LangGraph recursion limit from 25 to 50 steps
- Complex demo flows (vector search → failed deploy → retry → describe) can exceed 25 steps during Act 3
- Updates unit test to verify the new limit

## Test plan
- [x] Unit test updated to assert `RECURSION_LIMIT === 50`
- [x] Full test suite passes (390 passed, 68 skipped — integration tests needing infrastructure)
- [ ] Verify on live cluster that Act 3 flow completes without hitting limit

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the recursion limit for agent reasoning operations, enabling the system to handle more complex multi-step workflows with deeper reasoning chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->