### PR TITLE
feat(inference): add exampleYaml to capability descriptions

### DIFF
--- a/prompts/capability-inference.md
+++ b/prompts/capability-inference.md
@@ -33,7 +33,9 @@ Your job is to extract structured information that helps a developer understand 
 
 6. Write a **useCase** sentence describing when and why a developer would use this resource. Start with a verb like "Deploy", "Configure", "Manage".
 
-7. Rate your **confidence** from 0 to 1. Use 0.9+ when the schema is detailed and descriptive. Use 0.5-0.8 when the schema is sparse or ambiguous. Use below 0.5 only when the schema provides almost no useful information.
+7. Write a minimal **exampleYaml** manifest showing a valid resource with apiVersion, kind, metadata.name, and the key spec fields filled in with realistic example values. Keep it short — only include fields that a developer would typically set. Use YAML format (not JSON).
+
+8. Rate your **confidence** from 0 to 1. Use 0.9+ when the schema is detailed and descriptive. Use 0.5-0.8 when the schema is sparse or ambiguous. Use below 0.5 only when the schema provides almost no useful information.
 
 ## Examples
 
@@ -47,6 +49,7 @@ A resource with fields like `spec.parameters.engine` (postgresql, mysql), `spec.
   "complexity": "low",
   "description": "Managed SQL database that abstracts away infrastructure details, supporting multiple database engines.",
   "useCase": "Deploy a managed SQL database without dealing with provider-specific configuration.",
+  "exampleYaml": "apiVersion: devopstoolkit.live/v1beta1\nkind: SQL\nmetadata:\n  name: my-database\nspec:\n  engine: postgresql\n  size: medium",
   "confidence": 0.92
 }
 ```
@@ -61,6 +64,7 @@ A resource in the `s3.aws.upbound.io` API group with fields like `spec.forProvid
   "complexity": "medium",
   "description": "AWS S3 bucket with configurable access policies, versioning, and lifecycle rules.",
   "useCase": "Configure cloud object storage for application data, backups, or static assets.",
+  "exampleYaml": "apiVersion: s3.aws.upbound.io/v1beta1\nkind: Bucket\nmetadata:\n  name: my-bucket\nspec:\n  forProvider:\n    region: us-east-1",
   "confidence": 0.9
 }
 ```
@@ -75,6 +79,7 @@ A resource in the core `v1` API with fields `data` (map of strings) and `binaryD
   "complexity": "low",
   "description": "Stores non-confidential configuration data as key-value pairs for pods to consume.",
   "useCase": "Configure application settings, feature flags, or environment-specific values without rebuilding container images.",
+  "exampleYaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\ndata:\n  DATABASE_URL: postgresql://localhost:5432/mydb",
   "confidence": 0.95
 }
 ```

--- a/src/pipeline/inference.test.ts
+++ b/src/pipeline/inference.test.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Unit tests for LLM capability inference (M2).
+// ABOUTME: Verifies schema-to-capability mapping, prompt construction, and batch processing.
+
 /**
  * inference.test.ts - Unit tests for LLM capability inference (M2)
  *
@@ -53,6 +56,13 @@ function makeLlmResult(
       "Managed database solution supporting multiple SQL engine types.",
     useCase:
       "Deploy a managed SQL database without dealing with infrastructure complexity.",
+    exampleYaml: `apiVersion: devopstoolkit.live/v1beta1
+kind: SQL
+metadata:
+  name: my-database
+spec:
+  engine: postgresql
+  size: small`,
     confidence: 0.9,
     ...overrides,
   };
@@ -95,6 +105,8 @@ describe("inferCapability", () => {
     expect(result.useCase).toBe(
       "Deploy a managed SQL database without dealing with infrastructure complexity."
     );
+    expect(result.exampleYaml).toContain("apiVersion: devopstoolkit.live/v1beta1");
+    expect(result.exampleYaml).toContain("kind: SQL");
     expect(result.confidence).toBe(0.9);
   });
 

--- a/src/pipeline/inference.ts
+++ b/src/pipeline/inference.ts
@@ -1,3 +1,6 @@
+// ABOUTME: LLM capability inference for the pipeline (M2).
+// ABOUTME: Sends CRD schemas to Claude Haiku and returns structured ResourceCapability descriptions.
+
 /**
  * inference.ts - LLM capability inference for the pipeline (M2)
  *
@@ -65,6 +68,11 @@ export const LlmCapabilitySchema = z.object({
     .string()
     .describe(
       "When and why a developer would use this resource. Start with a verb like 'Deploy', 'Configure', 'Manage'."
+    ),
+  exampleYaml: z
+    .string()
+    .describe(
+      "A minimal, valid YAML manifest for this resource showing the apiVersion, kind, metadata.name, and key spec fields with example values. Use realistic but simple values."
     ),
   confidence: z
     .number()

--- a/src/pipeline/storage.test.ts
+++ b/src/pipeline/storage.test.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Unit tests for vector storage of capability descriptions (M3).
+// ABOUTME: Tests ResourceCapability-to-VectorDocument mapping and store orchestration.
+
 /**
  * storage.test.ts - Unit tests for vector storage of capability descriptions (M3)
  *
@@ -34,6 +37,13 @@ function makeCapability(
       "Managed database solution supporting multiple SQL engine types.",
     useCase:
       "Deploy a managed SQL database without dealing with infrastructure complexity.",
+    exampleYaml: `apiVersion: devopstoolkit.live/v1beta1
+kind: SQL
+metadata:
+  name: my-database
+spec:
+  engine: postgresql
+  size: small`,
     confidence: 0.9,
     ...overrides,
   };
@@ -128,6 +138,18 @@ describe("capabilityToDocument", () => {
     const doc = capabilityToDocument(capability);
 
     expect(doc.text).toContain("high");
+  });
+
+  it("includes exampleYaml in embedding text", () => {
+    const capability = makeCapability({
+      exampleYaml: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config",
+    });
+
+    const doc = capabilityToDocument(capability);
+
+    expect(doc.text).toContain("Example YAML");
+    expect(doc.text).toContain("apiVersion: v1");
+    expect(doc.text).toContain("kind: ConfigMap");
   });
 
   it("stores kind in metadata for filtering", () => {

--- a/src/pipeline/storage.ts
+++ b/src/pipeline/storage.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Vector database storage for capability descriptions (M3).
+// ABOUTME: Maps ResourceCapability to VectorDocument and stores in Chroma/Qdrant.
+
 /**
  * storage.ts - Vector database storage for capability descriptions (M3)
  *
@@ -132,6 +135,11 @@ function buildEmbeddingText(capability: ResourceCapability): string {
   // Description and use case
   lines.push(capability.description);
   lines.push(`Use case: ${capability.useCase}`);
+
+  // Example YAML for manifest construction
+  if (capability.exampleYaml) {
+    lines.push(`Example YAML:\n${capability.exampleYaml}`);
+  }
 
   return lines.join("\n");
 }

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Shared data types for the capability and instance pipelines (M1-M3).
+// ABOUTME: Defines DiscoveredResource, ResourceCapability, and pipeline option interfaces.
+
 /**
  * types.ts - Shared data types for the capability and instance pipelines
  *
@@ -184,6 +187,8 @@ export interface ResourceCapability {
   description: string;
   /** When and why a developer would use this resource */
   useCase: string;
+  /** Minimal example YAML manifest showing valid spec fields */
+  exampleYaml: string;
   /** LLM's confidence in its analysis (0 = guessing, 1 = certain) */
   confidence: number;
 }


### PR DESCRIPTION
## Summary
- Adds `exampleYaml` field to `ResourceCapability` type and Zod schema
- Updates inference prompt to ask the LLM for a minimal valid YAML manifest
- Includes example YAML in vector DB embedding text so the agent finds it via search
- Updates all three prompt examples with `exampleYaml` values

This gives the agent enough context to construct valid manifests on first attempt instead of guessing spec fields.

## Test plan
- [x] New storage test: `exampleYaml` included in embedding text
- [x] Inference test: `exampleYaml` returned in capability result
- [x] Full test suite passes (391 passed, 68 skipped — integration tests needing infrastructure)
- [ ] Re-sync capabilities on live cluster, verify agent constructs valid ManagedService manifest

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example YAML manifests to resource capability information, providing users with concrete, minimal examples showing API version, kind, metadata, and key specification fields for each resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->