### PR TITLE
feat(setup): sync via ingress URLs instead of port-forwards

### DIFF
--- a/demo/cluster/setup.sh
+++ b/demo/cluster/setup.sh
@@ -493,6 +493,8 @@ metadata:
   namespace: chroma
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
 spec:
   ingressClassName: nginx
   rules:
@@ -517,6 +519,9 @@ kind: Ingress
 metadata:
   name: qdrant
   namespace: qdrant
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
 spec:
   ingressClassName: nginx
   rules:
@@ -1421,6 +1426,8 @@ print_summary() {
         log_info "Ingress URLs:"
         log_info "  cluster-whisperer: http://cluster-whisperer.${BASE_DOMAIN}"
         log_info "  Jaeger UI:         http://jaeger.${BASE_DOMAIN}"
+        log_info "  Chroma:            http://chroma.${BASE_DOMAIN}"
+        log_info "  Qdrant:            http://qdrant.${BASE_DOMAIN}"
     fi
     echo ""
     log_info "To use this cluster:"


### PR DESCRIPTION
## Summary
- Reorders setup so `create_ingress_resources` runs before sync steps
- Adds Chroma and Qdrant ingress resources (previously only cluster-whisperer and Jaeger had ingress)
- Replaces fragile port-forward lifecycle in `run_capability_inference`, `run_instance_sync`, and `verify_vector_search` with stable ingress URLs
- Moves `deploy_cluster_whisperer_serve` before `create_ingress_resources` since the ingress needs the service to exist
- Port-forwards still used for quick health probes in `verify_vector_dbs` and `verify_observability` (run before ingress is available)

## Test plan
- [x] Shell syntax validation passes (`bash -n`)
- [ ] Manual: full `setup.sh gcp` passes end-to-end with new ordering
- [ ] Manual: verify Chroma/Qdrant ingress URLs respond after setup

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster deployment configuration to use Kubernetes Ingress-based service connectivity for improved networking setup.
  * Reorganized initialization sequence for streamlined cluster deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->