### PR TITLE
feat(setup): verify trace pipeline end-to-end (Jaeger + Datadog)

### DIFF
--- a/demo/cluster/setup.sh
+++ b/demo/cluster/setup.sh
@@ -1000,6 +1000,7 @@ verify_trace_pipeline() {
     kubectl port-forward -n otel-collector \
         svc/otel-collector-opentelemetry-collector "${otlp_port}:${otlp_port}" &>/dev/null &
     local otlp_pf_pid=$!
+    trap "kill ${otlp_pf_pid} 2>/dev/null || true; wait ${otlp_pf_pid} 2>/dev/null || true" EXIT
     sleep 2
 
     log_info "Sending test trace via agent query..."
@@ -1010,6 +1011,7 @@ verify_trace_pipeline() {
 
     kill "${otlp_pf_pid}" 2>/dev/null || true
     wait "${otlp_pf_pid}" 2>/dev/null || true
+    trap - EXIT
 
     # Wait for trace propagation
     log_info "Waiting for trace propagation (10s)..."
@@ -1019,6 +1021,7 @@ verify_trace_pipeline() {
     kubectl port-forward -n jaeger \
         deploy/jaeger 16686:16686 &>/dev/null &
     local jaeger_pf_pid=$!
+    trap "kill ${jaeger_pf_pid} 2>/dev/null || true; wait ${jaeger_pf_pid} 2>/dev/null || true" EXIT
     sleep 2
 
     local jaeger_services
@@ -1040,6 +1043,7 @@ verify_trace_pipeline() {
 
     kill "${jaeger_pf_pid}" 2>/dev/null || true
     wait "${jaeger_pf_pid}" 2>/dev/null || true
+    trap - EXIT
 
     if [[ "${trace_verified}" != "true" ]]; then
         log_error "Trace pipeline verification failed: cluster-whisperer not found in Jaeger after 30s"


### PR DESCRIPTION
## Summary
- Adds `verify_trace_pipeline` function that sends a test trace with `OTEL_TRACING_ENABLED=true` and verifies it arrives in Jaeger via the API
- Queries Jaeger `/api/services` endpoint to confirm `cluster-whisperer` service appears (retries up to 3 times over 30s)
- Advisory Datadog verification when `DD_API_KEY`/`DD_APP_KEY` are set — warns but doesn't fail
- EXIT traps on port-forward processes to prevent orphaned kubectl processes on interruption
- Catches config issues that health checks alone miss (tracing not enabled, collector not forwarding)

## Test plan
- [x] Shell syntax validation passes (`bash -n`)
- [x] CodeRabbit CLI finding addressed (port-forward trap cleanup)
- [ ] Manual: verify on live GKE cluster that test trace appears in Jaeger
- [ ] Manual: verify Datadog advisory check with DD_API_KEY/DD_APP_KEY set

Closes #67