### PR TITLE
fix: increase setup.sh timeouts for GKE stabilization

### DIFF
--- a/demo/cluster/setup.sh
+++ b/demo/cluster/setup.sh
@@ -1098,7 +1098,7 @@ verify_vector_dbs() {
     log_info "Verifying vector database health..."
 
     local failures=0
-    local retries=6
+    local retries=12
     local retry_interval=10
 
     # Chroma health check with retries: GET /api/v1/heartbeat
@@ -1187,7 +1187,7 @@ install_jaeger() {
         --namespace jaeger \
         --create-namespace \
         --values "${SCRIPT_DIR}/helm-values/jaeger.yaml" \
-        --wait --timeout 180s
+        --wait --timeout 300s
 
     log_success "Jaeger installed"
 


### PR DESCRIPTION
## Description

**What does this PR do?**

Increases timeouts in `demo/cluster/setup.sh` to prevent failures during GKE control plane resize:

- Vector DB health checks: 6 → 12 retries (60s → 120s total)
- Jaeger helm install timeout: 180s → 300s

**Why is this change needed?**

After installing Chroma + Qdrant, GKE auto-resizes the control plane due to the high object count (~335 CRDs). The existing `wait_for_gke_operations` + `wait_for_api_server` checks pass, but port-forward connections remain flaky for another ~60s. The previous 60s retry window wasn't enough, and Jaeger's 180s helm timeout expired during the same window.

## Related Issues

None — observed during fresh GKE cluster setup on 2026-03-16.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Checklist

- [ ] Tests added or updated
- [x] Manual testing performed

**Test results:**
Shell script change — no unit tests applicable. Verified the timeout values are reasonable based on observed GKE resize timing (~3-4 minutes).

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] PR title follows Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster initialization reliability by increasing timeout tolerances for vector database health verification and monitoring service deployment, reducing potential setup failures under high-load conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->