### PR TITLE
fix(agent): replace deprecated stateModifier with prompt

### DIFF
--- a/src/agent/investigator.test.ts
+++ b/src/agent/investigator.test.ts
@@ -120,8 +120,10 @@ describe("getInvestigatorAgent", () => {
     getInvestigatorAgent();
 
     const callArgs = mockCreateReactAgent.mock.calls[0][0];
-    expect(callArgs.stateModifier).toBeTruthy();
-    expect(callArgs.stateModifier).toContain("Kubernetes");
+    // Uses `prompt` (not deprecated `stateModifier`) per LangGraph v0.2.46+
+    expect(callArgs.prompt).toBeTruthy();
+    expect(callArgs.prompt).toContain("Kubernetes");
+    expect(callArgs.stateModifier).toBeUndefined();
   });
 
   it("filters to kubectl-only when toolGroups is ['kubectl']", async () => {

--- a/src/agent/investigator.ts
+++ b/src/agent/investigator.ts
@@ -312,7 +312,7 @@ export function getInvestigatorAgent(options?: InvestigatorOptions) {
     const agent = createReactAgent({
       llm: model,
       tools,
-      stateModifier: getSystemPrompt(),
+      prompt: getSystemPrompt(),
       // Checkpointer enables conversation memory — the agent saves state
       // after each step so multi-turn conversations persist across CLI invocations.
       // Without a checkpointer, each invocation starts fresh (one-shot mode).


### PR DESCRIPTION
## Description

**What does this PR do?**
Replaces the deprecated `stateModifier` parameter with `prompt` in `createReactAgent()`.

**Why is this change needed?**
`stateModifier` was deprecated in LangGraph v0.2.46. The installed version is 0.2.74. While it still works, a future minor/patch bump could turn this into a hard error — no agent, no KubeCon demo.

## Related Issues

Closes #91

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Checklist

- [x] Tests added or updated
- [x] All existing tests pass locally
- [x] Test coverage maintained or improved

**Test commands run:**
```bash
npx vitest run
```

**Test results:**
661 passed, 72 skipped (integration tests needing infrastructure), 0 failed.

## Security Checklist

- [x] No secrets or credentials committed

## Breaking Changes

- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] PR title follows Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for agent initialization validation to verify correct parameter configuration.

* **Chores**
  * Updated internal agent configuration to maintain compatibility with current library versions. System prompt behavior and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->