### PR TITLE
docs: rewritten KubeCon abstract

### DIFF
--- a/docs/abstract.md
+++ b/docs/abstract.md
@@ -1,0 +1,9 @@
+# Choose Your Own Adventure — Abstract
+
+Our hero app lives in a Kubernetes cluster supported by an Internal Developer Platform built with Crossplane and OpenTelemetry. But the developers want more: can an AI agent make their experience even smoother?
+
+In this interactive session, the audience will vote at key moments to guide the investigation of a broken app — with help from AI. We'll explore three categories of AI tooling: agent frameworks, vector databases, and observability backends. At each step, we'll introduce a concept, present options, and let the audience decide which to use in the live demo.
+
+This talk isn't just about how AI works — it's about how an AI agent can interface with and enrich a modern platform.
+
+Will our AI choices help or hinder? However it goes, you'll see how an agent with the right tools can investigate and deploy on behalf of a developer who has no direct cluster access. Expect surprises, stumbles, and a lively discussion about what AI is (and isn't) ready for in platform engineering.


### PR DESCRIPTION
## Description

Rewrites the Choose Your Own Adventure abstract to match the actual demo flow. Keeps the original tone and structure but updates the specifics: Crossplane + OpenTelemetry (not the full CNCF stack), agent frameworks / vector databases / observability backends (not models / agents / MCP), investigating a broken app (not idea to deployment).

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added talk abstract for "Choose Your Own Adventure" session featuring an interactive narrative on AI-assisted exploration in cloud-native environments.
  * Documentation outlines key AI tooling categories, live-demo structure, and integration approaches with modern platform workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->