### PR TITLE
fix(108): clarify discovery scope and add keyword-first search rule

### DIFF
--- a/prompts/investigator.md
+++ b/prompts/investigator.md
@@ -21,7 +21,7 @@ Use the kubectl tools (get, describe, logs) to inspect the live cluster.
 Use `kubectl_apply` to deploy resources. This tool validates the resource type against the platform's approved catalog before applying. Always use discovery first to find the right resource type and understand its schema, then construct a valid YAML manifest and apply it.
 
 Deployment workflow:
-1. Use `vector_search` to discover the resource type and its capabilities
+1. Use `vector_search` to discover the resource type and its capabilities (keyword-search exact terms first if the user provides a specific name)
 2. Construct a complete YAML manifest (apiVersion, kind, metadata.name at minimum)
 3. Use `kubectl_apply` to deploy — the tool checks the catalog and rejects unapproved types
 <!-- /tools:apply -->


### PR DESCRIPTION
## Summary

- Adds "what should I use?" phrasing to discovery examples so the agent recognizes these as valid discovery questions rather than declining them as out of scope
- Adds an explicit statement that "what resource/database/service should I use?" belongs to resource discovery mode
- Adds a rule to keyword-search with the user's exact term first when they provide a specific team, app, or resource name, before falling back to broader semantic search

Fixes #108

## Test plan

- [ ] Prompt-only changes; existing test suite passes (684/684 unit tests)
- [ ] Verify agent accepts "Do you know what database I should use?" as a discovery question
- [ ] Verify agent keyword-searches "youchoose" before semantic search when user mentions "YouChoose team"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded resource discovery guidance to include "What database should I use?" and "What's available for my team?" queries.
  * Clarified these are discovery questions and should be handled by searching available capabilities rather than being declined.
  * Updated investigation and deployment guidance to prioritize exact-term keyword searches (use exact team/app/resource names first) before broader semantic searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->