### PR TITLE
fix(112): make discovery questions in-scope regardless of tool availability

### DIFF
--- a/prompts/investigator.md
+++ b/prompts/investigator.md
@@ -33,7 +33,7 @@ Deployment workflow:
 - For discovery questions, search capabilities first, then verify with kubectl
 - When the user provides a specific team name, app name, or resource name, keyword-search with that exact term first before using broader semantic search terms
 <!-- /tools:vector -->
-- For investigation questions, start broad, then narrow down to specific problems
+- For investigation questions, start broad (e.g. list pods), then narrow down to specific problems. Investigate first — do not ask the user for details you can discover yourself
 <!-- tools:apply -->
 - For deployment requests, always discover the resource type first, then apply
 <!-- /tools:apply -->


### PR DESCRIPTION
## Summary

- Adds always-present vocabulary mapping: "the platform" = this Kubernetes cluster, "capabilities" = CRDs and deployable resource types
- Moves Resource discovery mode definition outside `<!-- tools:vector -->` tags so the agent always knows discovery questions are in-scope
- Keeps vector_search-specific instructions gated; adds kubectl fallback (list CRDs, describe promising ones) outside the gate

During a demo run, the agent refused "which database should I use?" when running with only kubectl tools because all discovery guidance was inside vector-gated sections that got stripped. Now discovery is always a recognized mode — only the tool-specific instructions are conditional.

Fixes #112

## Test plan

- [ ] Prompt-only changes; existing test suite passes (684/684 unit tests)
- [ ] Verify agent accepts "What database should I use?" in kubectl-only mode
- [ ] Verify agent lists CRDs as fallback when vector search is unavailable
- [ ] Verify vector search path still works when available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified platform semantics and definition of available capabilities
  * Enhanced discovery flow: prioritize vector search, fallback to explicit CRD inspection
  * Deployment flow now emphasizes discovering resource types/capabilities before manifest construction and validates manifests against the platform catalog
  * Minor wording and sequencing tweaks to streamline workflows

* **Documentation**
  * Investigation guidance broadened: start broadly, describe reasoning and intended tool usage before actions, and include discovery, verification, and deep-dive steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->