### PR TITLE
fix: retry kubectl apply on GKE after CRD burst

### DIFF
--- a/demo/cluster/setup.sh
+++ b/demo/cluster/setup.sh
@@ -1841,8 +1841,10 @@ deploy_cluster_whisperer_serve() {
                 applied=true
                 break
             fi
-            echo -e "  ${BLUE}[attempt ${i}/${retries}]${NC} kubectl apply failed, retrying in ${retry_interval}s..."
-            sleep "$retry_interval"
+            if [[ $i -lt $retries ]]; then
+                echo -e "  ${BLUE}[attempt ${i}/${retries}]${NC} kubectl apply failed, retrying in ${retry_interval}s..."
+                sleep "$retry_interval"
+            fi
         done
         if [[ "${applied}" != "true" ]]; then
             log_error "Failed to apply cluster-whisperer manifest after ${retries} attempts"


### PR DESCRIPTION
## Summary
- After registering 300+ CRDs, the GKE control plane may auto-resize, causing transient TLS handshake timeouts on the API server
- Wraps the cluster-whisperer manifest apply in a retry loop (5 attempts, 15s apart) to ride out the transient unavailability
- Captures kubectl stderr so non-transient errors (invalid YAML, RBAC issues) are visible on final failure

## Test plan
- [ ] Run `./demo/cluster/setup.sh gcp` and verify the cluster-whisperer serve step completes
- [ ] Verify that if a real manifest error occurs, the error message is shown (not suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved cluster deployment robustness by adding an automatic retry flow for applying manifests, with multiple attempts and delays, clearer error reporting that captures the last apply output, cleanup of temporary artifacts on failure, and a clean non-zero exit when persistent failures occur—reducing flaky deploys and making failures easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->