### PR TITLE
fix: increase Qdrant helm timeout for GKE

### DIFF
--- a/demo/cluster/setup.sh
+++ b/demo/cluster/setup.sh
@@ -1176,7 +1176,7 @@ install_qdrant() {
         --namespace qdrant \
         --create-namespace \
         --values "${SCRIPT_DIR}/helm-values/qdrant.yaml" \
-        --wait --timeout 180s
+        --wait --timeout 300s
 
     log_success "Qdrant installed"
 


### PR DESCRIPTION
## Summary
- Increased Qdrant Helm install timeout from 180s to 300s to accommodate GKE PVC provisioning latency
- StatefulSet PVC provisioning on GKE is slower than in-memory deployments, causing `context deadline exceeded` failures
- 300s matches the Jaeger Helm timeout which works reliably

## Test plan
- [x] Verified Qdrant pod eventually comes up healthy on GKE with current 180s timeout (just takes longer)
- [ ] Next GKE cluster setup should pass the Qdrant install step without timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the initialization timeout for cluster deployment setup from 180 to 300 seconds to improve deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->