### PR TITLE
fix: truncate large tool results to prevent context window overflow

### DIFF
--- a/src/agent/vercel-agent.ts
+++ b/src/agent/vercel-agent.ts
@@ -127,6 +127,7 @@ export class VercelAgent implements InvestigationAgent {
     // the system parameter, NOT in the messages array.
     const result = streamText({
       model: anthropic(ANTHROPIC_MODEL),
+      maxOutputTokens: 16000,
       system: systemPrompt,
       ...(threadId
         ? { messages: inputMessages }

--- a/src/tools/langchain/index.ts
+++ b/src/tools/langchain/index.ts
@@ -54,6 +54,7 @@ import {
   type KubectlOptions,
 } from "../core";
 import { withToolTracing } from "../../tracing/tool-tracing";
+import { truncateToolResult } from "../../utils/truncate";
 import type { VectorStore } from "../../vectorstore";
 import {
   CAPABILITIES_COLLECTION,
@@ -80,7 +81,7 @@ export function createKubectlTools(options?: KubectlOptions) {
       { name: "kubectl_get", description: kubectlGetDescription },
       async (input: KubectlGetInput) => {
         const { output } = await kubectlGet(input, options);
-        return output;
+        return truncateToolResult(output);
       }
     ),
     {
@@ -95,7 +96,7 @@ export function createKubectlTools(options?: KubectlOptions) {
       { name: "kubectl_describe", description: kubectlDescribeDescription },
       async (input: KubectlDescribeInput) => {
         const { output } = await kubectlDescribe(input, options);
-        return output;
+        return truncateToolResult(output);
       }
     ),
     {
@@ -110,7 +111,7 @@ export function createKubectlTools(options?: KubectlOptions) {
       { name: "kubectl_logs", description: kubectlLogsDescription },
       async (input: KubectlLogsInput) => {
         const { output } = await kubectlLogs(input, options);
-        return output;
+        return truncateToolResult(output);
       }
     ),
     {

--- a/src/tools/vercel/index.ts
+++ b/src/tools/vercel/index.ts
@@ -52,6 +52,7 @@ import {
   type KubectlOptions,
 } from "../core";
 import { withToolTracing } from "../../tracing/tool-tracing";
+import { truncateToolResult } from "../../utils/truncate";
 import type { VectorStore } from "../../vectorstore";
 import {
   CAPABILITIES_COLLECTION,
@@ -78,7 +79,7 @@ export function createKubectlTools(options?: KubectlOptions) {
         { name: "kubectl_get", description: kubectlGetDescription },
         async (input: KubectlGetInput) => {
           const { output } = await kubectlGet(input, options);
-          return output;
+          return truncateToolResult(output);
         }
       ),
     }),
@@ -90,7 +91,7 @@ export function createKubectlTools(options?: KubectlOptions) {
         { name: "kubectl_describe", description: kubectlDescribeDescription },
         async (input: KubectlDescribeInput) => {
           const { output } = await kubectlDescribe(input, options);
-          return output;
+          return truncateToolResult(output);
         }
       ),
     }),
@@ -102,7 +103,7 @@ export function createKubectlTools(options?: KubectlOptions) {
         { name: "kubectl_logs", description: kubectlLogsDescription },
         async (input: KubectlLogsInput) => {
           const { output } = await kubectlLogs(input, options);
-          return output;
+          return truncateToolResult(output);
         }
       ),
     }),

--- a/src/utils/truncate.test.ts
+++ b/src/utils/truncate.test.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Unit tests for truncateToolResult — verifies head+tail truncation for LLM context safety.
+// ABOUTME: Tests no-op for short text, correct splitting for long text, and custom limits.
+
+import { describe, it, expect } from "vitest";
+import { truncateToolResult } from "./truncate";
+
+describe("truncateToolResult", () => {
+  it("returns text unchanged when under the limit", () => {
+    const short = "NAME   READY   STATUS\nnginx  1/1     Running\n";
+    expect(truncateToolResult(short)).toBe(short);
+  });
+
+  it("returns text unchanged when exactly at the limit", () => {
+    const exact = "x".repeat(50000);
+    expect(truncateToolResult(exact)).toBe(exact);
+  });
+
+  it("truncates text over the limit with head + tail", () => {
+    const long = "H".repeat(30000) + "M".repeat(40000) + "T".repeat(30000);
+    const result = truncateToolResult(long);
+
+    expect(result.length).toBeLessThan(long.length);
+    // Head should start with H's
+    expect(result.startsWith("H")).toBe(true);
+    // Tail should end with T's
+    expect(result.endsWith("T")).toBe(true);
+    // Separator message should be present
+    expect(result).toContain("characters omitted to fit context window");
+  });
+
+  it("preserves roughly equal head and tail portions", () => {
+    const long = "A".repeat(60000);
+    const result = truncateToolResult(long);
+
+    // Split on the separator
+    const parts = result.split("characters omitted to fit context window");
+    expect(parts).toHaveLength(2);
+
+    // Both parts should have substantial content
+    const headPart = parts[0];
+    const tailPart = parts[1];
+    expect(headPart.length).toBeGreaterThan(20000);
+    expect(tailPart.length).toBeGreaterThan(20000);
+  });
+
+  it("includes the correct omitted character count in the separator", () => {
+    // 70K chars, limit 50K, separator ~100 chars → keep ~24,950 each side
+    // omitted = 70000 - 2*24950 = 20100
+    const long = "x".repeat(70000);
+    const result = truncateToolResult(long);
+
+    // Extract the number from the separator
+    const match = result.match(/(\d+) characters omitted/);
+    expect(match).not.toBeNull();
+    const omitted = parseInt(match![1], 10);
+    // Should be roughly 20K (70K - 50K)
+    expect(omitted).toBeGreaterThan(19000);
+    expect(omitted).toBeLessThan(21000);
+  });
+
+  it("respects a custom maxChars limit", () => {
+    const text = "x".repeat(2000);
+    const result = truncateToolResult(text, 1000);
+
+    expect(result.length).toBeLessThan(2000);
+    expect(result).toContain("characters omitted");
+  });
+
+  it("does not truncate when custom limit is larger than text", () => {
+    const text = "x".repeat(200);
+    expect(truncateToolResult(text, 300)).toBe(text);
+  });
+});

--- a/src/utils/truncate.ts
+++ b/src/utils/truncate.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Truncates large tool results to fit within LLM context windows.
+// ABOUTME: Keeps both head and tail of output so Events sections (at the bottom of kubectl describe) aren't lost.
+
+/**
+ * Truncates tool result text to prevent context window overflow.
+ *
+ * Why head + tail instead of just head?
+ * kubectl describe puts Events at the bottom — that's the most useful section
+ * for troubleshooting. A naive head-only truncation would cut off the gold.
+ * Keeping both ends preserves the resource metadata (top) and Events (bottom),
+ * while trimming the verbose middle (OpenAPI schemas, base64 certs, etc.).
+ *
+ * Why 50,000 characters?
+ * ~12,500 tokens. Large enough that normal kubectl output (pods, services,
+ * logs, resource describes) is never truncated. Only fires for degenerate
+ * cases like Crossplane CRD describes with full OpenAPI validation schemas.
+ * Even with 3 large results hitting the cap, total is ~37.5K tokens —
+ * well within a 200K context window.
+ *
+ * @param text - The full tool output
+ * @param maxChars - Maximum characters to keep (default 50,000)
+ * @returns The original text if under the limit, or head + tail with a gap marker
+ */
+export function truncateToolResult(
+  text: string,
+  maxChars: number = 50000
+): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  // Reserve space for the separator message (~100 chars)
+  const separatorBudget = 100;
+  const keepEach = Math.floor((maxChars - separatorBudget) / 2);
+  const head = text.slice(0, keepEach);
+  const tail = text.slice(-keepEach);
+  const omitted = text.length - keepEach * 2;
+
+  return `${head}\n\n... [${omitted} characters omitted to fit context window] ...\n\n${tail}`;
+}


### PR DESCRIPTION
## Summary

- Adds `truncateToolResult()` utility (50K char limit, head+tail) to prevent massive kubectl output (e.g., Crossplane CRD describes with full OpenAPI schemas) from blowing the 200K context window
- Applies truncation in both Vercel and LangChain tool wrappers for kubectl_get, kubectl_describe, and kubectl_logs
- Sets `maxOutputTokens: 16000` on the Vercel agent — was missing, causing the SDK to default to 64K which alone made the context arithmetic impossible (141K input + 64K output > 200K limit)

## Test plan

- [x] 7 unit tests for `truncateToolResult` (no-op for short text, head+tail split, correct omitted count, custom limits)
- [x] All 620 existing unit tests pass
- [x] TypeScript typecheck clean
- [ ] Manual demo run: multi-turn investigation with CRD describes no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased maximum output token limits to enable longer AI responses
  * Implemented intelligent output truncation for command-line tools to preserve context window capacity while maintaining relevant output segments

* **Tests**
  * Added comprehensive test coverage for output truncation, including edge cases and custom limit configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->