### PR TITLE
fix(setup): apply named provider-kubernetes MRAP unconditionally on CRD activation failure

### DIFF
--- a/demo/cluster/setup.sh
+++ b/demo/cluster/setup.sh
@@ -1093,7 +1093,7 @@ configure_provider_kubernetes() {
                 # which case kubectl patch returns exit 0 with "no change" — the
                 # controller sees no diff and never re-evaluates. A separately named
                 # MRAP is a genuinely new resource that forces controller processing.
-                kubectl apply -f - <<'MRAP_EOF' 2>/dev/null || true
+                if kubectl apply -f - <<'MRAP_EOF' 2>/dev/null; then
 apiVersion: apiextensions.crossplane.io/v1alpha1
 kind: ManagedResourceActivationPolicy
 metadata:
@@ -1103,8 +1103,11 @@ spec:
   - "*.kubernetes.crossplane.io"
   - "*.kubernetes.m.crossplane.io"
 MRAP_EOF
-                mrap_refreshed=true
-                log_info "  MRAP applied — waiting for activation..."
+                    mrap_refreshed=true
+                    log_info "  MRAP applied — waiting for activation..."
+                else
+                    log_warning "  Failed to apply dedicated MRAP; will retry while waiting for CRD activation..."
+                fi
             fi
         fi
 

--- a/demo/cluster/setup.sh
+++ b/demo/cluster/setup.sh
@@ -1087,11 +1087,12 @@ configure_provider_kubernetes() {
             local inactive_count
             inactive_count=$(kubectl get mrds 2>/dev/null | grep "kubernetes.*Inactive" | wc -l | tr -d ' ') || inactive_count=0
             if [[ $inactive_count -gt 0 ]]; then
-                log_info "  Found ${inactive_count} Inactive kubernetes MRDs — refreshing default MRAP..."
-                # Patch the default MRAP to trigger re-evaluation of all MRDs
-                kubectl patch mrap default --type=merge \
-                    -p '{"spec":{"activate":["*"]}}' 2>/dev/null || \
-                # If no default MRAP exists, create one
+                log_info "  Found ${inactive_count} Inactive kubernetes MRDs — applying dedicated MRAP..."
+                # Apply a named MRAP for provider-kubernetes resources. The default
+                # MRAP (activate: ["*"]) may already exist with identical spec, in
+                # which case kubectl patch returns exit 0 with "no change" — the
+                # controller sees no diff and never re-evaluates. A separately named
+                # MRAP is a genuinely new resource that forces controller processing.
                 kubectl apply -f - <<'MRAP_EOF' 2>/dev/null || true
 apiVersion: apiextensions.crossplane.io/v1alpha1
 kind: ManagedResourceActivationPolicy
@@ -1103,7 +1104,7 @@ spec:
   - "*.kubernetes.m.crossplane.io"
 MRAP_EOF
                 mrap_refreshed=true
-                log_info "  MRAP refreshed — waiting for activation..."
+                log_info "  MRAP applied — waiting for activation..."
             fi
         fi
 


### PR DESCRIPTION
## Summary

- Fixes a race condition in Crossplane v2's MRAP activation for `provider-kubernetes`
- The previous code patched the default MRAP (`activate: ["*"]`), but if it already existed with identical spec, `kubectl patch` returns exit 0 with "no change" — the MRAP controller sees no diff and never re-evaluates the Inactive MRDs
- Fix: apply a named `provider-kubernetes` MRAP directly (always, not as a fallback), which is a genuinely new resource that forces the controller to process and activate the kubernetes MRDs

## Test plan

- [ ] Run `./demo/cluster/setup.sh gcp` end-to-end and confirm `objects.kubernetes.crossplane.io` activates successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched MRAP activation in the demo cluster setup to apply a dedicated MRAP resource instead of modifying the default, ensuring MRD activation via an embedded manifest
  * Improved setup logging to indicate MRAP application and to wait for activation completion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->